### PR TITLE
refactor metrics

### DIFF
--- a/main.go
+++ b/main.go
@@ -17,7 +17,6 @@ import (
 )
 
 var Lenz *lenz.LenzForwarder
-var Metrics *metrics.MetricsRecorder
 
 var Status *StatusMoniter
 var VLan *VLanSetter
@@ -44,7 +43,7 @@ func main() {
 	)
 
 	Lenz = lenz.NewLenz(config.Lenz)
-	Metrics = metrics.NewMetricsRecorder(config.HostName, config.Metrics)
+	metrics.Metrics = metrics.NewMetricsRecorder(config.HostName, config.Metrics)
 
 	utils.WritePid(config.PidFile)
 	defer os.Remove(config.PidFile)

--- a/main_test.go
+++ b/main_test.go
@@ -17,7 +17,7 @@ func InitTest() {
 	if Lenz == nil {
 		Lenz = lenz.NewLenz(config.Lenz)
 	}
-	if Metrics == nil {
-		Metrics = metrics.NewMetricsRecorder(config.HostName, config.Metrics)
+	if metrics.Metrics == nil {
+		metrics.Metrics = metrics.NewMetricsRecorder(config.HostName, config.Metrics)
 	}
 }

--- a/status.go
+++ b/status.go
@@ -8,6 +8,7 @@ import (
 	"./common"
 	"./defines"
 	"./logs"
+	"./metrics"
 	"./utils"
 	"github.com/fsouza/go-dockerclient"
 	"github.com/keimoon/gore"
@@ -34,7 +35,7 @@ func (self *StatusMoniter) Listen() {
 		case common.STATUS_DIE:
 			// Check if exists
 			if _, ok := self.Apps[event.ID]; ok {
-				go Metrics.Remove(event.ID)
+				go metrics.Metrics.Remove(event.ID)
 				delete(self.Apps, event.ID)
 				reportContainerDeath(event.ID)
 			}
@@ -152,7 +153,7 @@ func (self *StatusMoniter) Add(ID, containerName string) {
 	logs.Debug("Container", name, entrypoint, ident)
 	app := &defines.App{name, entrypoint, ident}
 	self.Apps[ID] = app
-	go Metrics.Add(ID, app)
+	go metrics.Metrics.Add(ID, app)
 	Lenz.Attacher.Attach(ID, app)
 	reportContainerCure(ID)
 }


### PR DESCRIPTION
不主动退出 goroutine 主要是因为 veth 会莫名其妙的消失导致 getstats 失败。

但是我们的 metrics 并不关心 docker0 带来的 veth，只关心 vnbe 开头的 macvlan 网卡。

所以从主动推出 goroutine 改为了通过判断 metrics 里面是否还记录这个 container，没记录的话就主动退出了
