### PR TITLE
fix report cure

### DIFF
--- a/status/status.go
+++ b/status/status.go
@@ -106,7 +106,6 @@ func monitor() {
 				app.Add(eruApp)
 				lenz.Attacher.Attach(&eruApp.Meta)
 				reportContainerCure(event.ID)
-				logs.Debug(event.ID, "cured, added in watching list")
 			}
 		}
 	}
@@ -131,16 +130,17 @@ func getContainerMeta(cid string) map[string]interface{} {
 
 	containersKey := fmt.Sprintf("eru:agent:%s:containers:meta", g.Config.HostName)
 	rep, err := gore.NewCommand("HGET", containersKey, cid).Run(conn)
-	if err != nil || rep.IsNil() {
-		logs.Info("Status get target", err)
+	if err != nil {
+		logs.Info("Status get meta", err)
 		return nil
 	}
 	var result map[string]interface{}
 	if b, err := rep.Bytes(); err != nil {
 		logs.Info("Status get meta", err)
+		return nil
 	} else {
 		if err := json.Unmarshal(b, &result); err != nil {
-			logs.Info("Status get meta", err)
+			logs.Info("Status unmarshal meta", err)
 			return nil
 		}
 	}
@@ -170,6 +170,7 @@ func reportContainerDeath(cid string) {
 	client := &http.Client{}
 	req, _ := http.NewRequest("PUT", url, nil)
 	client.Do(req)
+	logs.Debug(cid[:12], "dead, remove from watching list")
 }
 
 func reportContainerCure(cid string) {
@@ -177,4 +178,5 @@ func reportContainerCure(cid string) {
 	client := &http.Client{}
 	req, _ := http.NewRequest("PUT", url, nil)
 	client.Do(req)
+	logs.Debug(cid[:12], "cured, added in watching list")
 }


### PR DESCRIPTION
1. 现在再不济也要求给个字典到 meta key 中
2. 逻辑是
   a. 如果容器是曾经监控过的，中途死掉了再起的时候会激发各种监控
   b. 按照 启动1 发 pubsub2 写 meta3 的顺序，event 监控因为这时候读不到 meta 会忽略 start 事件，等待 pubsub 来把 eventid 加入到列表
