### PR TITLE
fix blocking when update stats

### DIFF
--- a/app/eru.go
+++ b/app/eru.go
@@ -57,19 +57,20 @@ func NewEruApp(ID, containerName string, extend map[string]interface{}) *EruApp 
 var lock sync.RWMutex
 var Apps map[string]*EruApp = map[string]*EruApp{}
 
-func Add(app *EruApp) {
+func Add(app *EruApp) bool {
 	lock.Lock()
 	defer lock.Unlock()
 	if _, ok := Apps[app.ID]; ok {
 		// safe add
-		return
+		return false
 	}
 	if !app.InitMetric() {
 		// not record
-		return
+		return false
 	}
 	go app.Report()
 	Apps[app.ID] = app
+	return true
 }
 
 func Remove(ID string) {

--- a/app/metric.go
+++ b/app/metric.go
@@ -74,8 +74,17 @@ func (self *EruApp) updateStats() bool {
 			logs.Info("Get stats failed", err)
 		}
 	}()
-	stats := <-statsChan
-	if stats == nil {
+
+	var stats *docker.Stats
+	select {
+	case stats = <-statsChan:
+		// 很幸运拿到了数据, 那么继续
+		if stats == nil {
+			return false
+		}
+	case <-time.After(2 * time.Second):
+		// 超时了, 那就直接返回吧
+		// biè 一直 block 住别人
 		return false
 	}
 

--- a/status/status.go
+++ b/status/status.go
@@ -84,8 +84,9 @@ func monitor() {
 			// Check if exists
 			if app.Valid(event.ID) {
 				app.Remove(event.ID)
-				reportContainerDeath(event.ID)
 			}
+			// 死了就发送吧, 无所谓
+			reportContainerDeath(event.ID)
 		case common.STATUS_START:
 			// if not in watching list, just ignore it
 			if meta := getContainerMeta(event.ID); meta != nil && !app.Valid(event.ID) {
@@ -99,7 +100,10 @@ func monitor() {
 					logs.Info("Create EruApp failed")
 					break
 				}
-				app.Add(eruApp)
+				if !app.Add(eruApp) {
+					logs.Info("EruApp Add failed")
+					break
+				}
 				lenz.Attacher.Attach(&eruApp.Meta)
 				reportContainerCure(event.ID)
 			}


### PR DESCRIPTION
我其实在想这样修改有没有意义. 解决的问题就是:
1. 容器起来就挂, 可以正确返回了
2. 解决了容器起来就退出的时候的死锁情况, 但是其实那个锁锁着感觉也没什么问题...

带来的问题是每次容器死了就有一个上报, 不管是不是需要监管的容器.

所以我觉得 @neuront 遇到的问题可能是容器直接很快退出了... 
