### PR TITLE
无差别对待吧

### DIFF
--- a/app/metric.go
+++ b/app/metric.go
@@ -76,7 +76,7 @@ func (self *EruApp) updateStats() bool {
 		}
 	}()
 
-	var stats *docker.Stats
+	stats := &docker.Stats{}
 	select {
 	case stats = <-statsChan:
 		if stats == nil {

--- a/status/status.go
+++ b/status/status.go
@@ -81,11 +81,8 @@ func monitor() {
 		logs.Debug("Status", event.Status, event.ID[:12], event.From)
 		switch event.Status {
 		case common.STATUS_DIE:
-			// Check if exists
-			if app.Valid(event.ID) {
-				app.Remove(event.ID)
-				reportContainerDeath(event.ID)
-			}
+			app.Remove(event.ID)
+			reportContainerDeath(event.ID)
 		case common.STATUS_START:
 			// if not in watching list, just ignore it
 			if meta := getContainerMeta(event.ID); meta != nil && !app.Valid(event.ID) {


### PR DESCRIPTION
容器起来就 `exit` 的情况. 有时候因为时序的关系, `InitMetric` 会直接失败, 那这时候 `app.Valid` 肯定会失败, 但是需要清除掉这个, 就无差别对待吧.
